### PR TITLE
chore(merge): update merge commit filtering in release notes configuration

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -17,6 +17,8 @@ module.exports = {
             if (commit.header && typeof commit.header === 'string') {
               if (commit.header.startsWith('chore(pr):')) return null
               if (commit.header.startsWith('chore(merge):')) return null
+              if (commit.header.startsWith('Merge pull request')) return null
+              if (commit.header.startsWith('Merge branch')) return null
             }
 
             // Return a shallow copy instead of mutating the provided object.


### PR DESCRIPTION
Refine the filtering logic to exclude specific merge commit headers from the release notes.